### PR TITLE
Feature/formulario controlado

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -28,6 +28,7 @@ import { MatDialogModule } from '@angular/material/dialog';
 import { BotaoControleComponent } from './shared/botao-controle/botao-controle.component';
 import { HttpClientModule } from '@angular/common/http';
 import { PromocoesComponent } from './pages/home/promocoes/promocoes.component';
+import { ReactiveFormsModule } from '@angular/forms';
 
 @NgModule({
   declarations: [
@@ -60,7 +61,8 @@ import { PromocoesComponent } from './pages/home/promocoes/promocoes.component';
     MatDatepickerModule,
     MatNativeDateModule,
     MatDialogModule,
-    HttpClientModule
+    HttpClientModule,
+    ReactiveFormsModule
   ],
   providers: [],
   bootstrap: [AppComponent]

--- a/src/app/core/services/form-busca.service.spec.ts
+++ b/src/app/core/services/form-busca.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { FormBuscaService } from './form-busca.service';
+
+describe('FormBuscaService', () => {
+  let service: FormBuscaService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(FormBuscaService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/core/services/form-busca.service.ts
+++ b/src/app/core/services/form-busca.service.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class FormBuscaService {
+
+  formBusca: FormGroup
+
+  constructor() {
+    this.formBusca = new FormGroup({})
+  }
+}

--- a/src/app/core/services/form-busca.service.ts
+++ b/src/app/core/services/form-busca.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { FormGroup } from '@angular/forms';
+import { FormControl, FormGroup } from '@angular/forms';
 
 @Injectable({
   providedIn: 'root'
@@ -9,6 +9,8 @@ export class FormBuscaService {
   formBusca: FormGroup
 
   constructor() {
-    this.formBusca = new FormGroup({})
+    this.formBusca = new FormGroup({
+      somenteIda: new FormControl(false)
+    })
   }
 }

--- a/src/app/core/services/unidade-federativa.service.spec.ts
+++ b/src/app/core/services/unidade-federativa.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { UnidadeFederativaService } from './unidade-federativa.service';
+
+describe('UnidadeFederativaService', () => {
+  let service: UnidadeFederativaService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(UnidadeFederativaService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/core/services/unidade-federativa.service.ts
+++ b/src/app/core/services/unidade-federativa.service.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@angular/core';
+import { Observable, shareReplay } from 'rxjs';
+import { environment } from 'src/environments/environment';
+import { UnidadeFederativa } from '../types/types';
+import { HttpClient } from '@angular/common/http';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class UnidadeFederativaService {
+  private apiUrl: string = environment.apiUrl
+  private cache$?: Observable<UnidadeFederativa[]>
+
+  constructor(
+    private http: HttpClient
+  ) { }
+
+  listar(): Observable<UnidadeFederativa[]> {
+    if (!this.cache$) {
+      this.cache$ = this.requestEstados().pipe(
+        shareReplay(1)
+      );
+    }
+
+    return this.cache$;
+  }
+
+  private requestEstados(): Observable<UnidadeFederativa[] {
+    return this.http.get<UnidadeFederativa[]>(`${this.apiUrl}/estados`);
+  }
+}

--- a/src/app/core/types/types.ts
+++ b/src/app/core/types/types.ts
@@ -4,3 +4,9 @@ export interface Promocao {
 	imagem: string;
 	preco: number;
 }
+
+export interface UnidadeFederativa {
+	id: number;
+	nome: string;
+	sigla: string;
+}

--- a/src/app/shared/form-busca/form-busca.component.html
+++ b/src/app/shared/form-busca/form-busca.component.html
@@ -1,13 +1,16 @@
 <app-card variant="secondary" class="form-busca">
-	<form>
+	<form [formGroup]="formBuscaService.formBusca">
 	  <h2>Passagens</h2>
 	  <div class="flex-container">
-		<mat-button-toggle-group aria-label="Tipo de passagem">
-		  <mat-button-toggle checked>
-			<mat-icon>check</mat-icon>
+		<mat-button-toggle-group aria-label="Tipo de passagem" formControlName="somenteIda">
+		  <mat-button-toggle [value]="false">
+			<mat-icon *ngIf="!formBuscaService.formBusca.get('somenteIda')?.value">check</mat-icon>
 			IDA E VOLTA
 		  </mat-button-toggle>
-		  <mat-button-toggle>SOMENTE IDA</mat-button-toggle>
+		  <mat-button-toggle [value]="true">
+			<mat-icon *ngIf="formBuscaService.formBusca.get('somenteIda')?.value">check</mat-icon>
+			SOMENTE IDA
+		</mat-button-toggle>
 		</mat-button-toggle-group>
 		<mat-chip-listbox (click)="openDialog()" aria-label="Seleção de passagens">
 		  <mat-chip-option selected>1 adulto</mat-chip-option>

--- a/src/app/shared/form-busca/form-busca.component.ts
+++ b/src/app/shared/form-busca/form-busca.component.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { ModalComponent } from '../modal/modal.component';
+import { FormBuscaService } from 'src/app/core/services/form-busca.service';
 
 @Component({
   selector: 'app-form-busca',
@@ -8,7 +9,8 @@ import { ModalComponent } from '../modal/modal.component';
   styleUrls: ['./form-busca.component.scss']
 })
 export class FormBuscaComponent {
-  constructor(public dialog: MatDialog) { }
+  constructor(public dialog: MatDialog,
+    public formBuscaService: FormBuscaService) { }
 
   openDialog() {
     this.dialog.open(ModalComponent, {


### PR DESCRIPTION
Este PR implementa um formulário de busca para passagens no componente FormBuscaComponent, com integração ao serviço FormBuscaService para gerenciar o estado do formulário. As alterações incluem:

Adição de campos no formulário de busca:

O formulário possui um campo somenteIda que permite ao usuário selecionar entre "IDA E VOLTA" e "SOMENTE IDA" usando o mat-button-toggle-group.
Utilização do MatDialog para abrir um modal de seleção de passagens ao clicar na lista de chips (ex: "1 adulto").
Criação do serviço FormBuscaService:

O serviço FormBuscaService contém um FormGroup com o controle somenteIda, que gerencia o estado do campo "IDA E VOLTA" / "SOMENTE IDA".
Uso de cache no serviço UnidadeFederativaService:

Implementação de cache no serviço UnidadeFederativaService para otimizar as requisições e evitar chamadas repetidas à API ao listar as unidades federativas.
Ajustes em testes:

Foi incluído um teste de unidade básico para o serviço FormBuscaService e UnidadeFederativaService, garantindo que os serviços sejam criados corretamente.
Objetivo do PR: Este PR tem como objetivo melhorar a funcionalidade de busca de passagens, otimizando a interação do usuário ao selecionar diferentes opções de viagem e garantindo o correto funcionamento do formulário com o uso de formulários reativos e cache.